### PR TITLE
Add startupProbe to unneeded fields

### DIFF
--- a/telepresence/proxy/deployment.py
+++ b/telepresence/proxy/deployment.py
@@ -427,8 +427,8 @@ def new_swapped_deployment(
             container["imagePullPolicy"] = "IfNotPresent"
             # Drop unneeded fields:
             for unneeded in [
-                "args", "livenessProbe", "readinessProbe", "workingDir",
-                "lifecycle"
+                "args", "startupProbe", "livenessProbe", "readinessProbe",
+                "workingDir", "lifecycle"
             ]:
                 try:
                     container.pop(unneeded)

--- a/telepresence/proxy/operation.py
+++ b/telepresence/proxy/operation.py
@@ -227,8 +227,8 @@ class Swap(ProxyOperation):
         })
 
         for unneeded in [
-            "args", "livenessProbe", "startupProbe", "readinessProbe", "workingDir",
-            "lifecycle"
+            "args", "livenessProbe", "startupProbe", "readinessProbe",
+            "workingDir", "lifecycle"
         ]:
             try:
                 container.pop(unneeded)

--- a/tests/local/test_unit.py
+++ b/tests/local/test_unit.py
@@ -102,7 +102,13 @@ spec:
         ports:
         - containerPort: 80
           name: http-api
-          protocol: TCP      
+          protocol: TCP
+        startupProbe:
+          httpGet:
+            path: /index.html
+            port: 80
+          initialDelaySeconds: 30
+          timeoutSeconds: 1
         livenessProbe:
           httpGet:
             path: /index.html
@@ -163,7 +169,19 @@ spec:
         workingDir: "/somewhere/over/the/rainbow"
         ports:
         - containerPort: 443
-        - containerPort: 80               
+        - containerPort: 80
+        startupProbe:
+          httpGet:
+            path: /index.html
+            port: 80
+          initialDelaySeconds: 30
+          timeoutSeconds: 1
+        livenessProbe:
+          httpGet:
+            path: /index.html
+            port: 80
+          initialDelaySeconds: 30
+          timeoutSeconds: 1
         readinessProbe:
           httpGet:
             path: /index.html


### PR DESCRIPTION
Fix test cases and remove extra whitespace



---

## Helpful information

- CircleCI will run the linters and unit tests on your PR.
  - The results of that CI run will be listed as "check-local."
  - You can run the same tests yourself:

    ```shell
    make lint check-local
    ```

  - The other checks for your PR will succeed immediately without testing anything. They rely on Datawire secrets to push images or talk to a Kubernetes cluster, so they are disabled for forked-repo PRs.

- Please include a changelog entry as a file `newsfragments/issue_number.type`.
  - `type` is one of `incompat`, `feature`, `bugfix`, or `misc`
  - E.g., `1003.bugfix` would contain the text
    > Attaching a debugger to the process running under Telepresence no longer causes the session to end.
  - You can preview the changelog with

    ```shell
    virtualenv/bin/towncrier --draft
    ```

- Please delete this pre-filled text ("Helpful information"). Note that you can edit the description after submitting the PR if you prefer.

Thank you for your contribution!
